### PR TITLE
Add ExtractedServiceError

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -16,6 +16,13 @@ class ServiceNotFoundError extends Error {
   }
 }
 
+class ExtractedServiceError extends Error {
+  constructor(name) {
+    // prettier-ignore
+    super('Service with name \'' + name + '\' has been extracted from the core dai.js library into a discrete plugin. Please refer to the documentation here to install and add it to your configuration: \n\n https://github.com/makerdao/dai.js/wiki/Basic-Usage-(Plugins) \n\n');
+  }
+}
+
 // exported just for testing
 export function orderServices(services) {
   const edges = [];
@@ -52,8 +59,14 @@ class Container {
   }
 
   service(name, throwIfMissing = true) {
+    const extractedServices = ['exchange'];
+
     if (!name) {
       throw new Error('Provide a service name.');
+    }
+
+    if (!this._services[name] && throwIfMissing && extractedServices.includes(name)) {
+      throw new ExtractedServiceError(name);
     }
 
     if (!this._services[name] && throwIfMissing) {
@@ -109,6 +122,7 @@ class Container {
 
 export {
   Container as default,
+  ExtractedServiceError,
   InvalidServiceError,
   ServiceAlreadyRegisteredError,
   ServiceNotFoundError

--- a/test/Container.spec.js
+++ b/test/Container.spec.js
@@ -1,4 +1,5 @@
 import Container, {
+  ExtractedServiceError,
   InvalidServiceError,
   ServiceAlreadyRegisteredError,
   ServiceNotFoundError,
@@ -62,6 +63,12 @@ test('service() should return a registered service by name', () => {
 test('service() should by default throw when a service is not found', () => {
   expect(() => new Container().service('IDontExist')).toThrow(
     ServiceNotFoundError.Error
+  );
+});
+
+test('service() should throw when trying to access an extracted service', () => {
+  expect(()=> new Container().service('exchange')).toThrow(
+    ExtractedServiceError.Error
   );
 });
 


### PR DESCRIPTION
We throw an error in dai.js if the exchange service is specified in the configuration without having the plugin installed, but we don't cover the cases like https://github.com/makerdao/dai.js/issues/131, when a user might expect it to have been configured by default and attempt to access it (e.g. `maker.service('exchange')`). This throws a more helpful error in this case, and it can also be used for whatever plugins we extract in the future.